### PR TITLE
Fix volume deletion for populated volumes

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -65,6 +65,7 @@ var (
 	testEnvExt *envtestutils.EnvironmentExtensions
 	cfg        *rest.Config
 	k8sClient  client.Client
+	rookConfig *rook.Config
 
 	volumeClassSelector = map[string]string{
 		"suitable-for": "testing",
@@ -196,7 +197,7 @@ func SetupTest(ctx context.Context) (*corev1.Namespace, *corev1.Namespace, *core
 
 		// register reconciler here
 
-		rookConfig := rook.NewConfigWithDefaults()
+		rookConfig = rook.NewConfigWithDefaults()
 		rookConfig.Namespace = rookNamespace.Name
 
 		Expect((&VolumeReconciler{
@@ -225,6 +226,7 @@ func SetupTest(ctx context.Context) (*corev1.Namespace, *corev1.Namespace, *core
 			PopulatorPodDevicePath: defaultDevicePath,
 			PopulatorNamespace:     populatorNamespace.Name,
 			Prefix:                 defaultPrefix,
+			RookConfig:             rookConfig,
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		go func() {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/api v0.24.4
 	k8s.io/apimachinery v0.24.4
 	k8s.io/client-go v0.24.4
+	k8s.io/component-helpers v0.24.4
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.3
 )

--- a/go.sum
+++ b/go.sum
@@ -2502,6 +2502,8 @@ k8s.io/component-base v0.20.4/go.mod h1:t4p9EdiagbVCJKrQ1RsA5/V4rFQNDfRlevJajlGw
 k8s.io/component-base v0.20.6/go.mod h1:6f1MPBAeI+mvuts3sIdtpjljHWBQ2cIy38oBIWMYnrM=
 k8s.io/component-base v0.24.3 h1:u99WjuHYCRJjS1xeLOx72DdRaghuDnuMgueiGMFy1ec=
 k8s.io/component-base v0.24.3/go.mod h1:bqom2IWN9Lj+vwAkPNOv2TflsP1PeVDIwIN0lRthxYY=
+k8s.io/component-helpers v0.24.4 h1:gjginN6YYh/s3xg3PQ0gTFqBRGo27/wdLn0vRmJdHu8=
+k8s.io/component-helpers v0.24.4/go.mod h1:xAHlOKU8rAjLgXWJEsueWLR1LDMThbaPf2YvgKpSyQ8=
 k8s.io/cri-api v0.17.3/go.mod h1:X1sbHmuXhwaHs9xxYffLqJogVsnI+f6cPRcgPel7ywM=
 k8s.io/cri-api v0.20.1/go.mod h1:2JRbKt+BFLTjtrILYVqQK5jqhI+XNdF6UiGMgczeBCI=
 k8s.io/cri-api v0.20.4/go.mod h1:2JRbKt+BFLTjtrILYVqQK5jqhI+XNdF6UiGMgczeBCI=

--- a/main.go
+++ b/main.go
@@ -150,6 +150,7 @@ func main() {
 		PopulatorPodDevicePath: populatorDevicePath,
 		PopulatorNamespace:     populatorNamespace,
 		Prefix:                 populatorPrefix,
+		RookConfig:             rookConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImagePopulator")
 		os.Exit(1)


### PR DESCRIPTION
# Proposed Changes

The current implementation does not set the correct annotations on the underlying PV. This causes the deletion flow to stop as those annotations indicate which CSI to use for the deletion process.

