### PR TITLE
Set rbd imageFeatures to better default values

### DIFF
--- a/pkg/rook/config.go
+++ b/pkg/rook/config.go
@@ -22,7 +22,7 @@ const (
 	CSIRBDNodeSecretNameDefaultValue             = "rook-csi-rbd-node"
 	StorageClassAllowVolumeExpansionDefaultValue = true
 	StorageClassFSTypeDefaultValue               = "ext4"
-	StorageClassImageFeaturesDefaultValue        = "layering"
+	StorageClassImageFeaturesDefaultValue        = "layering,exclusive-lock,object-map,fast-diff"
 	StorageClassReclaimPolicyDefaultValue        = "Delete"
 	StorageClassVolumeBindingModeDefaultValue    = "Immediate"
 	CSIDriverNameDefaultValue                    = "rook-ceph.rbd.csi.ceph.com"


### PR DESCRIPTION
Set rbd imageFeatures to better default values:
`layering,exclusive-lock,object-map,fast-diff`

Old value `layering` has not been updated in Rook documentation for a longer time.
Currently Ceph-CSI supports more features and this should be reflected in the default values.