### PR TITLE
Add integraton tests

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,6 +35,9 @@ autolabeler:
   - label: 'controllers'
     files:
       - '/controllers/*'
+  - label: 'integration-tests'
+    files:
+      - 'integration/*'
   - label: 'documentation'
     files:
       - '*.md'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,104 @@
+name: Run integration tests
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'integration-tests')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Setup MicroCeph
+        run: |
+          set -x
+          sudo apt-get install --no-install-recommends -y snapd ceph-common
+          sudo snap install microceph --edge
+          sleep 5
+          sudo microceph cluster bootstrap
+          sudo microceph.ceph config set global osd_pool_default_size 1
+          sudo microceph.ceph config set global mon_allow_pool_delete true
+          sudo microceph.ceph config set global osd_memory_target 939524096
+          sudo microceph.ceph osd crush rule rm replicated_rule
+          sudo microceph.ceph osd crush rule create-replicated replicated default osd
+          for flag in nosnaptrim noscrub nobackfill norebalance norecover noscrub nodeep-scrub; do
+              sudo microceph.ceph osd set $flag
+          done
+          # Use ephemeral disk mounted on /mnt for ceph OSD.
+          # The block-devices plug doesn't allow accessing /dev/loopX devices so we make those same devices
+          # available under alternate names (/dev/sdiY) that are not used inside GitHub Action runners.
+          sudo swapoff /mnt/swapfile
+          sudo rm -f /mnt/swapfile
+          loop_file="/mnt/ceph-osd.img"
+          sudo fallocate -l 10G "${loop_file}"
+          loop_dev="$(sudo losetup --show --direct-io=on --nooverlap -f "${loop_file}")"
+          devInfo=($(sudo stat -c '%t %T' "${loop_dev}"))
+          sudo mknod -m 0660 /dev/sdia b 0x"${devInfo[0]}" 0x"${devInfo[1]}"
+          sudo microceph disk add --wipe /dev/sdia
+          sudo rm -rf /etc/ceph
+          sudo ln -s /var/snap/microceph/current/conf/ /etc/ceph
+          sudo microceph enable rgw
+          sudo ceph osd pool create devpool 8
+
+      - name: Waiting for Ceph cluster and pools to be healthy
+        run: |
+          # Check Ceph Health
+          for i in {1..30}; do
+            health_status=$(ceph health | awk '{print $1}')
+            if [[ "$health_status" == "HEALTH_OK" || "$health_status" == "HEALTH_WARN" ]]; then
+              echo "Ceph is in an acceptable state: health_status."
+              break
+            fi
+              echo "Waiting for Ceph to reach a stable state..."
+              sleep 10
+          done
+
+          # Check Pools
+          pool_to_check="devpool"
+          pool_ready=false
+          for i in {1..30}; do  
+            pools=$(ceph osd lspools)
+            if [[ "$pools" == *"$pool_to_check"* ]]; then
+              pool_ready=true
+              break
+            fi
+            echo "Waiting for $pool_to_check pool to be ready..."
+            sleep 10
+          done
+          if $pool_ready; then
+            echo "$pool_to_check pool is ready."
+          else
+            echo "$pool_to_check pool is not ready. Exiting."
+            exit 1
+          fi
+          
+          sudo microceph.ceph status
+          sudo rm -f /snap/bin/rbd
+
+      - name: Set Environment Variables
+        run: |
+          echo "CEPH_USERNAME=admin" >> $GITHUB_ENV
+          echo "CEPH_POOLNAME=devpool" >> $GITHUB_ENV
+          echo "CEPH_CLIENTNAME=client.admin" >> $GITHUB_ENV
+          echo "CEPH_KEYRING_FILENAME=/etc/ceph/ceph.client.admin.keyring" >> $GITHUB_ENV
+          echo "CEPH_MONITORS=$(hostname):6789" >> $GITHUB_ENV
+          echo "CEPH_CONFIG_FILE=/etc/ceph/ceph.conf" >> $GITHUB_ENV
+          sudo chmod +r /etc/ceph/ceph.client.admin.keyring
+
+      - name: Install dependencies
+        run: |
+          sudo apt install -y libcephfs-dev librbd-dev librados-dev
+
+      - name: Run go tests
+        run: |
+          make integration-tests 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest checklicense ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: intefration-tests
+integration-tests:
+	CGO=1 go test -tags=integration ./...
+
 .PHONY: addlicense
 addlicense: ## Add license headers to all go files.
 	find . -name '*.go' -exec go run github.com/google/addlicense -c 'OnMetal authors' {} +

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest checklicense ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -- -coverprofile cover.out -ginkgo.label-filter="!integration"
 
 .PHONY: intefration-tests
 integration-tests:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test: manifests generate fmt vet envtest checklicense ## Run tests.
 
 .PHONY: intefration-tests
 integration-tests:
-	CGO=1 go test -tags=integration ./...
+	CGO=1 go test ./... -- -ginkgo.label-filter="integration"
 
 .PHONY: addlicense
 addlicense: ## Add license headers to all go files.

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,11 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest checklicense ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -- -coverprofile cover.out -ginkgo.label-filter="!integration"
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go run github.com/onsi/ginkgo/v2/ginkgo --label-filter="!integration" -coverprofile cover.out ./...
 
 .PHONY: intefration-tests
 integration-tests:
-	CGO=1 go test ./... -- -ginkgo.label-filter="integration"
+	CGO=1 go run github.com/onsi/ginkgo/v2/ginkgo --label-filter="integration" ./...
 
 .PHONY: addlicense
 addlicense: ## Add license headers to all go files.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/addlicense v1.1.1
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1
 	github.com/onmetal/controller-utils v0.8.0
-	github.com/onmetal/onmetal-api v0.1.2-0.20230809123215-702b9aa69f8d
+	github.com/onmetal/onmetal-api v0.1.2-0.20230816135533-6e1562703753
 	github.com/onmetal/onmetal-image v0.1.1
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10

--- a/go.sum
+++ b/go.sum
@@ -1585,8 +1585,8 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.0-20180130162743-b8a9be070da4/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onmetal/controller-utils v0.8.0 h1:8rMDhtsoFGq1x26sha8W+Y7mGK5E4ALpudfoIL/w6hI=
 github.com/onmetal/controller-utils v0.8.0/go.mod h1:w57S36LruaLsRZ7DXC9E7TCa+H2iiXZW3JhvT8Hdilc=
-github.com/onmetal/onmetal-api v0.1.2-0.20230809123215-702b9aa69f8d h1:6hG30bqPBzMyjkm9CEmwrPnXbbDYELtzjiVVGhRx3no=
-github.com/onmetal/onmetal-api v0.1.2-0.20230809123215-702b9aa69f8d/go.mod h1:P/aSwZBU5RH7UP8eKrrnY0AjZsHhLFmY5wrx14OtGX8=
+github.com/onmetal/onmetal-api v0.1.2-0.20230816135533-6e1562703753 h1:jBvs1LfyXhJtGqs1SuVQPDUrzgOOphNWTks/aj36/zI=
+github.com/onmetal/onmetal-api v0.1.2-0.20230816135533-6e1562703753/go.mod h1:P/aSwZBU5RH7UP8eKrrnY0AjZsHhLFmY5wrx14OtGX8=
 github.com/onmetal/onmetal-image v0.1.1 h1:sGnK2a1OH2iHZSbOrFJEdP7UvFLXb+o9OhJM4/hMy/M=
 github.com/onmetal/onmetal-image v0.1.1/go.mod h1:+9CdnZneHl3seFnhJN+nGlJ1Npmd7Qs4VV3CHO86f1U=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-// +build integration
-
 package integration
 
 import (
@@ -47,7 +44,7 @@ var (
 
 func TestIntegration_GRPCServer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "GRPC Server Suite")
+	RunSpecs(t, "GRPC Server Suite", Label("integration"))
 }
 
 var _ = BeforeSuite(func() {

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -1,0 +1,141 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ceph/go-ceph/rados"
+	"github.com/onmetal/cephlet/ori/volume/cmd/volume/app"
+	"github.com/onmetal/onmetal-api/ori/apis/volume/v1alpha1"
+	"github.com/onmetal/onmetal-api/ori/remote/volume"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	srvCtx context.Context
+	cancel context.CancelFunc
+
+	volumeClient v1alpha1.VolumeRuntimeClient
+	ioctx        *rados.IOContext
+)
+
+func TestIntegration_GRPCServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GRPC Server Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	keyEncryptionKeyFile, err := os.CreateTemp(GinkgoT().TempDir(), "keyencryption")
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_ = keyEncryptionKeyFile.Close()
+	}()
+	Expect(os.WriteFile(keyEncryptionKeyFile.Name(), []byte("abcjdkekakakakakakakkadfkkasfdks"), 0666)).To(Succeed())
+
+	volumeClasses := []v1alpha1.VolumeClass{{
+		Name: "foo",
+		Capabilities: &v1alpha1.VolumeClassCapabilities{
+			Tps:  100,
+			Iops: 100,
+		},
+	}}
+	volumeClassesData, err := json.Marshal(volumeClasses)
+	Expect(err).NotTo(HaveOccurred())
+
+	volumeClassesFile, err := os.CreateTemp(GinkgoT().TempDir(), "volumeclasses")
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_ = volumeClassesFile.Close()
+	}()
+	Expect(os.WriteFile(volumeClassesFile.Name(), volumeClassesData, 0666)).To(Succeed())
+
+	opts := app.Options{
+		Address:                    fmt.Sprintf("%s/cephlet-volume.sock", os.Getenv("PWD")),
+		PathSupportedVolumeClasses: volumeClassesFile.Name(),
+		Ceph: app.CephOptions{
+			ConnectTimeout:       10 * time.Second,
+			Monitors:             os.Getenv("CEPH_MONITORS"),
+			User:                 os.Getenv("CEPH_USERNAME"),
+			KeyringFile:          os.Getenv("CEPH_KEYRING_FILENAME"),
+			Pool:                 os.Getenv("CEPH_POOLNAME"),
+			Client:               os.Getenv("CEPH_CLIENTNAME"),
+			KeyEncryptionKeyPath: keyEncryptionKeyFile.Name(),
+		},
+	}
+
+	srvCtx, cancel = context.WithCancel(context.Background())
+	DeferCleanup(cancel)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(app.Run(srvCtx, opts)).To(Succeed())
+	}()
+
+	Eventually(func() (bool, error) {
+		return isSocketAvailable(opts.Address)
+	}, "30s", "500ms").Should(BeTrue(), "The UNIX socket file should be available")
+
+	address, err := volume.GetAddressWithTimeout(3*time.Second, fmt.Sprintf("unix://%s", opts.Address))
+	Expect(err).NotTo(HaveOccurred())
+
+	gconn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	Expect(err).NotTo(HaveOccurred())
+
+	volumeClient = v1alpha1.NewVolumeRuntimeClient(gconn)
+	DeferCleanup(gconn.Close)
+
+	conn, err := rados.NewConn()
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(conn.ReadConfigFile(os.Getenv("CEPH_CONFIG_FILE"))).ToNot(HaveOccurred())
+
+	Expect(conn.Connect()).ToNot(HaveOccurred())
+	DeferCleanup(conn.Shutdown)
+
+	pools, err := conn.ListPools()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pools).To(ContainElement(opts.Ceph.Pool))
+
+	ioctx, err = conn.OpenIOContext(opts.Ceph.Pool)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(ioctx.Destroy)
+})
+
+func isSocketAvailable(socketPath string) (bool, error) {
+	fileInfo, err := os.Stat(socketPath)
+	if err != nil {
+		return false, err
+	}
+	if fileInfo.Mode()&os.ModeSocket != 0 {
+		return true, nil
+	}
+	return false, nil
+}

--- a/integration/volume_craete_integration_test.go
+++ b/integration/volume_craete_integration_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+
+	oriv1alpha1 "github.com/onmetal/cephlet/ori/volume/api/v1alpha1"
+	"github.com/onmetal/cephlet/pkg/api"
+	"github.com/onmetal/cephlet/pkg/omap"
+	metav1alpha1 "github.com/onmetal/onmetal-api/ori/apis/meta/v1alpha1"
+	onmetalv1alpha1 "github.com/onmetal/onmetal-api/ori/apis/volume/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create Volume", func() {
+	It("should get the supported volume classes", func(ctx SpecContext) {
+		resp, err := volumeClient.ListVolumeClasses(ctx, &onmetalv1alpha1.ListVolumeClassesRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.VolumeClasses).To(Equal([]*onmetalv1alpha1.VolumeClass{{
+			Name: "foo",
+			Capabilities: &onmetalv1alpha1.VolumeClassCapabilities{
+				Tps:  100,
+				Iops: 100,
+			},
+		}}))
+	})
+
+	It("should create a volume", func(ctx SpecContext) {
+		createResp, err := volumeClient.CreateVolume(ctx, &onmetalv1alpha1.CreateVolumeRequest{
+			Volume: &onmetalv1alpha1.Volume{
+				Metadata: &metav1alpha1.ObjectMetadata{
+					Id: "foo",
+				},
+				Spec: &onmetalv1alpha1.VolumeSpec{
+					Class: "foo",
+					Resources: &onmetalv1alpha1.VolumeResources{
+						StorageBytes: 1024 * 1024 * 1024,
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// Ensure the correct creation response
+		Expect(createResp).Should(SatisfyAll(
+			HaveField("Volume.Metadata.Id", Not(BeEmpty())),
+			HaveField("Volume.Spec.Image", Equal("")),
+			HaveField("Volume.Spec.Class", Equal("foo")),
+			HaveField("Volume.Spec.Resources.StorageBytes", Equal(uint64(1024*1024*1024))),
+			HaveField("Volume.Spec.Encryption", BeNil()),
+			HaveField("Volume.Status.State", Equal(onmetalv1alpha1.VolumeState_VOLUME_PENDING)),
+			HaveField("Volume.Status.Access", BeNil()),
+		))
+
+		resp, err := volumeClient.ListVolumes(ctx, &onmetalv1alpha1.ListVolumesRequest{
+			Filter: &onmetalv1alpha1.VolumeFilter{
+				Id: createResp.Volume.Metadata.Id,
+			},
+		})
+		Expect(resp.Volumes).NotTo(BeEmpty())
+
+		// Ensure the correct image has been created inside the ceph cluster
+		omap, err := ioctx.GetOmapValues(omap.OmapNameVolumes, "", createResp.Volume.Metadata.Id, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(omap).To(HaveKey(createResp.Volume.Metadata.Id))
+		image := &api.Image{}
+		Expect(json.Unmarshal(omap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
+		Expect(image).Should(SatisfyAll(
+			// TODO: finish comparison
+			HaveField("Metadata.ID", Equal(createResp.Volume.Metadata.Id)),
+			HaveField("Metadata.Labels", HaveKeyWithValue(oriv1alpha1.ClassLabel, "foo")),
+			HaveField("Spec.Image", Equal("")),
+			HaveField("Spec.Size", Equal(uint64(1024*1024*1024))),
+			HaveField("Status.State", Equal(api.ImageStatePending)),
+		))
+	})
+})

--- a/integration/volume_craete_integration_test.go
+++ b/integration/volume_craete_integration_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Create Volume", func() {
 				Id: createResp.Volume.Metadata.Id,
 			},
 		})
+		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Volumes).NotTo(BeEmpty())
 
 		// Ensure the correct image has been created inside the ceph cluster

--- a/integration/volume_craete_integration_test.go
+++ b/integration/volume_craete_integration_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-// +build integration
-
 package integration
 
 import (

--- a/integration/volume_craete_integration_test.go
+++ b/integration/volume_craete_integration_test.go
@@ -31,14 +31,18 @@ import (
 
 var _ = Describe("Create Volume", func() {
 	It("should get the supported volume classes", func(ctx SpecContext) {
-		resp, err := volumeClient.ListVolumeClasses(ctx, &onmetalv1alpha1.ListVolumeClassesRequest{})
+		resp, err := volumeClient.Status(ctx, &onmetalv1alpha1.StatusRequest{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.VolumeClasses).To(Equal([]*onmetalv1alpha1.VolumeClass{{
-			Name: "foo",
-			Capabilities: &onmetalv1alpha1.VolumeClassCapabilities{
-				Tps:  100,
-				Iops: 100,
+		Expect(resp.VolumeClassStatus).To(Equal([]*onmetalv1alpha1.VolumeClassStatus{{
+			VolumeClass: &onmetalv1alpha1.VolumeClass{
+				Name: "foo",
+				Capabilities: &onmetalv1alpha1.VolumeClassCapabilities{
+					Tps:  100,
+					Iops: 100,
+				},
 			},
+			// TODO: fix VolumeClass stats gathering
+			Quantity: 10177744896,
 		}}))
 	})
 


### PR DESCRIPTION
# Proposed Changes

- Start a ceph cluster using microceph inside GH runner instance
- Instanciate GRPC server
- Instanciate ORI client
- Ensure the correct behaviour by calling the corresponding ORI methods
- Ensure that the resources have been correctly created using the ceph-go rados client
- Bump `onmetal-api` deps

The integration workflow only runs when the `integration-tests` label is added to a PR.

The `integration` package contains a test suite and a first integration test for the `Volume` creation flow. The basic idea is to call ORI volume provided methods and ensure via a `ceph` client that the resources have been correctly created in the cluster.

To run the integration tests locally you need to pass the `integration` label to ginkgo:

```
go test ./... -ginkgo.label-filter="integration"
```

Fixes #315 